### PR TITLE
Ajout vérification connexion pushbullet close #10

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!
+  before_action :authenticate_user!, :check_pushbullet
 
   def home
     render json: { user: current_user, settings: current_user.pushbullet_setting }
+  end
+
+  def check_pushbullet
+    redirect_to pushbullet_init_path if current_user.pushbullet_setting.nil?
   end
 end

--- a/app/controllers/pushbullet_controller.rb
+++ b/app/controllers/pushbullet_controller.rb
@@ -5,6 +5,7 @@ require 'pushbullet'
 
 class PushbulletController < ApplicationController
   before_action :check_pushbullet_setting, only: %i[devices devices_pick]
+  skip_before_action :check_pushbullet
 
   def init
     client = OAuth2::Client.new(ENV['PUSHBULLET_CLIENT_ID'], ENV['PUSHBULLET_CLIENT_SECRET'], authorize_url: 'https://www.pushbullet.com/authorize')


### PR DESCRIPTION
- Ajout `before_action :check_pushbullet` dans `ApplicationController`
- Ajout `skip_before_action :check_pushbullet` dans `PushbulletController` sinon la page de connexion Pushbullet n'était pas accessible non plus et on entrait dans une boucle infinie de redirect